### PR TITLE
IntoExpr import is already in cookiecutter

### DIFF
--- a/docs/sum.md
+++ b/docs/sum.md
@@ -25,11 +25,6 @@ def sum_i64(expr: IntoExpr, other: IntoExpr) -> pl.Expr:
         args=[other]
     )
 ```
-Make sure to add
-```python
-from polars.type_aliases import IntoExpr
-```
-to the top of the file too.
 
 ## I’ve got 1100011 problems but binary ain't one
 


### PR DESCRIPTION
`IntoExpr` is already imported from the cookiecutter:

https://github.com/MarcoGorelli/cookiecutter-polars-plugins/blob/f9df272f29f7e81e2f937e006d255cefa90e321b/%7B%7B%20cookiecutter.project_slug%20%7D%7D/%7B%7B%20cookiecutter.project_slug%20%7D%7D/__init__.py#L10-L11