### PR TITLE
Replace binary_elementwise with broadcast_binary_elementwise in chapter 3

### DIFF
--- a/docs/sum.md
+++ b/docs/sum.md
@@ -29,8 +29,7 @@ def sum_i64(expr: IntoExpr, other: IntoExpr) -> pl.Expr:
 
 Time to write a binary function, in the sense that it takes two
 columns as input and produces a third.
-Polars gives us a handy `binary_elementwise` function for computing binary elementwise operations
-called `binary_elementwise`.
+Polars gives us a handy `broadcast_binary_elementwise` function for computing binary elementwise operations!
 
 Add the following to `src/expressions.rs`:
 
@@ -41,7 +40,7 @@ fn sum_i64(inputs: &[Series]) -> PolarsResult<Series> {
     let right: &Int64Chunked = inputs[1].i64()?;
     // Note: there's a faster way of summing two columns, see
     // section 7.
-    let out: Int64Chunked = binary_elementwise(
+    let out: Int64Chunked = broadcast_binary_elementwise(
         left,
         right,
         |left: Option<i64>, right: Option<i64>| match (left, right) {
@@ -54,7 +53,7 @@ fn sum_i64(inputs: &[Series]) -> PolarsResult<Series> {
 ```
 Note that you'll also need to add
 ```Rust
-use polars::prelude::arity::binary_elementwise;
+use polars::prelude::arity::broadcast_binary_elementwise;
 ```
 to the top of the `src/expressions.rs` file.
 

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unused_unit)]
-use polars::prelude::arity::binary_elementwise;
+use polars::prelude::arity::broadcast_binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use pyo3_polars::export::polars_core::export::num::Signed;
@@ -59,14 +59,13 @@ fn sum_i64(inputs: &[Series]) -> PolarsResult<Series> {
     let right: &Int64Chunked = inputs[1].i64()?;
     // Note: there's a faster way of summing two columns, see
     // section 7.
-    let out: Int64Chunked = binary_elementwise(
-        left,
-        right,
-        |left: Option<i64>, right: Option<i64>| match (left, right) {
+    let out: Int64Chunked =
+        broadcast_binary_elementwise(left, right, |left: Option<i64>, right: Option<i64>| match (
+            left, right,
+        ) {
             (Some(left), Some(right)) => Some(left + right),
             _ => None,
-        },
-    );
+        });
     Ok(out.into_series())
 }
 


### PR DESCRIPTION
Just a simple replacement on the SUM chapter: use `broadcast_binary_elementwise` instead of `binary_elementwise` (in case pl.lit(...) is passed as input)