### PR TITLE
Recommendation against Vec<Option<T>> with examples

### DIFF
--- a/docs/aggregate.md
+++ b/docs/aggregate.md
@@ -1,4 +1,4 @@
-# 13. In (the) aggregate
+# 14. In (the) aggregate
 
 Enough transorming columns! Let's aggregate them instead.
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,4 +1,4 @@
-# 12. Publishing your plugin to PyPI and becoming famous
+# 13. Publishing your plugin to PyPI and becoming famous
 
 Here are the steps you should follow:
 

--- a/docs/vec_of_option.md
+++ b/docs/vec_of_option.md
@@ -162,8 +162,10 @@ if first != 0 || last != chunked_arr.len() {
 ```
 
 Notice how only the outer nulls were set to invalid (if the inner nulls were as well, this wouldn't be a very good interpolation).
-The validity mask already exists for all Chunked types, so we could dismiss its overhead in this scenario.  
-__With this, the developers avoided returning a `Vec<Option<T>>`!__
+The validity mask is only allocated when there are no outer nulls.
+In that scenario, a `MutableBitmap` is used - which takes potentially much less space than storing contiguous `Option`s for the elements.
+
+__With this, the developers avoided allocating a `Vec<Option<T>>`!__
 
 
 ## Sentinel values
@@ -172,7 +174,7 @@ Another way of avoiding a `Vec<Option<T>>` is to use values known to be invalid 
 For instance, if you have a `Vec<i32>` that represents indices, negative values shouldn't ever be present in that vector.
 By leveraging this information, you could actually use negative values to represent invalid elements.
 
-Let's take a look at an example PR that got merged into Polars that does exactly that:
+Let's take a look at an example PR that got merged into polars-xdt (a plugin for DateTimes) that does exactly that:
 
 ```diff
 index b3e4907..2110a0d 100644
@@ -247,7 +249,7 @@ But memory-wise we already know the benefits!
 
 ## Conclusion
 
-In general, _if you can avoid returning `Vec<Option<T>>` instead of `Vec<T>`,_ __do it!__
+In general, _if you can avoid allocating `Vec<Option<T>>` instead of `Vec<T>`,_ __do it!__
 Of course this doesn't apply in every situation, but it's something important for plugin developers to have in mind.
 
 

--- a/docs/vec_of_option.md
+++ b/docs/vec_of_option.md
@@ -80,11 +80,11 @@ where
         validity.extend_constant(chunked_arr.len(), true);
 
         for i in 0..first {
-            unsafe { validity.set_unchecked(i, false) };
+            validity.set(i, false);
         }
 
         for i in last..chunked_arr.len() {
-            unsafe { validity.set_unchecked(i, false) };
+            validity.set(i, false);
             out.push(Zero::zero())
         }
 
@@ -139,13 +139,13 @@ if first != 0 || last != chunked_arr.len() {
     for i in 0..first {
         // The indexes corresponding to the zeroes before the first valid value
         // are set to false (invalid)
-        unsafe { validity.set_unchecked(i, false) };
+        validity.set(i, false);
     }
 
     for i in last..chunked_arr.len() {
         // The indexes corresponding to the values after the last valid value
         // are set to false (invalid)
-        unsafe { validity.set_unchecked(i, false) };
+        validity.set(i, false);
 
         out.push(Zero::zero())  // This is equivalent to the zeroes pushed
                                 // before the first valid value, it's just done

--- a/docs/vec_of_option.md
+++ b/docs/vec_of_option.md
@@ -1,5 +1,7 @@
 
-# 12. What are your `Option`s?
+# 12. `Vec<Option<T>>` vs. `Vec<T>`
+
+> "I got, I got, I got, I got options" – _Pitbull_, before writing his polars plugins
 
 One situation you might encounter when developing plugins or working with polars in rust is to decide whether to return a `Vec<T>` or a `Vec<Option<T>>`.
 A `Vec<Option<T>>` often seems like a good idea, as it's able to represent __invalid__ values without you having to resort to hacky workarounds.

--- a/minimal_plugin/__init__.py
+++ b/minimal_plugin/__init__.py
@@ -131,3 +131,12 @@ def vertical_weighted_mean(values: IntoExpr, weights: IntoExpr) -> pl.Expr:
         is_elementwise=False,
         returns_scalar=True,
     )
+
+
+def interpolate(expr: IntoExpr) -> pl.Expr:
+    return register_plugin(
+        args=[expr],
+        lib=lib,
+        symbol="interpolate",
+        is_elementwise=False,
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
     - lists_in_lists_out.md
   - struct.md
   - lost_in_space.md
+  - vec_of_option.md
   - publishing.md
   - aggregate.md
   - where_to_go.md

--- a/run.py
+++ b/run.py
@@ -22,3 +22,9 @@ df = pl.DataFrame({
     'group': ['a', 'a', 'a', 'b', 'b'],
 })
 print(df.group_by('group').agg(weighted_mean = mp.vertical_weighted_mean('values', 'weights')))
+
+df = pl.DataFrame({
+    'a': [None, None, 3, None, None, 9, 11, None],
+})
+result = df.with_columns(interpolate=mp.interpolate('a'))
+print(result)

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -424,13 +424,6 @@ where
     }
 }
 
-fn linear_interp_signed<T: PolarsNumericType>(ca: &ChunkedArray<T>) -> Series
-where
-    ChunkedArray<T>: IntoSeries,
-{
-    interpolate_impl(ca, signed_interp::<T::Native>).into_series()
-}
-
 #[polars_expr(output_type=Int64)]
 fn interpolate(inputs: &[Series]) -> PolarsResult<Series> {
     let s = &inputs[0];

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -1,11 +1,14 @@
 #![allow(clippy::unused_unit)]
+use polars::export::num::{NumCast, Zero};
 use polars::prelude::arity::broadcast_binary_elementwise;
 use polars::prelude::*;
+use polars_arrow::bitmap::MutableBitmap;
 use pyo3_polars::derive::polars_expr;
 use pyo3_polars::export::polars_core::export::num::Signed;
 use pyo3_polars::export::polars_core::utils::arrow::array::PrimitiveArray;
 use pyo3_polars::export::polars_core::utils::CustomIterTools;
 use serde::Deserialize;
+use std::ops::{Add, Div, Mul, Sub};
 
 use crate::utils::binary_amortized_elementwise;
 
@@ -331,4 +334,108 @@ fn vertical_weighted_mean(inputs: &[Series]) -> PolarsResult<Series> {
     });
     let result = numerator / denominator;
     Ok(Series::new("", vec![result]))
+}
+
+fn linear_itp<T>(low: T, step: T, slope: T) -> T
+where
+    T: Sub<Output = T> + Mul<Output = T> + Add<Output = T> + Div<Output = T>,
+{
+    low + step * slope
+}
+
+#[inline]
+fn signed_interp<T>(low: T, high: T, steps: IdxSize, steps_n: T, out: &mut Vec<T>)
+where
+    T: Sub<Output = T> + Mul<Output = T> + Add<Output = T> + Div<Output = T> + NumCast + Copy,
+{
+    let slope = (high - low) / steps_n;
+    for step_i in 1..steps {
+        let step_i: T = NumCast::from(step_i).unwrap();
+        let v = linear_itp(low, step_i, slope);
+        out.push(v)
+    }
+}
+
+fn interpolate_impl<T, I>(chunked_arr: &ChunkedArray<T>, interpolation_branch: I) -> ChunkedArray<T>
+where
+    T: PolarsNumericType,
+    I: Fn(T::Native, T::Native, IdxSize, T::Native, &mut Vec<T::Native>),
+{
+    // This implementation differs from pandas as that boundary None's are not removed.
+    // This prevents a lot of errors due to expressions leading to different lengths.
+    if chunked_arr.null_count() == 0 || chunked_arr.null_count() == chunked_arr.len() {
+        return chunked_arr.clone();
+    }
+
+    // We first find the first and last so that we can set the null buffer.
+    let first = chunked_arr.first_non_null().unwrap();
+    let last = chunked_arr.last_non_null().unwrap() + 1;
+
+    // Fill out with `first` nulls.
+    let mut out = Vec::with_capacity(chunked_arr.len());
+    let mut iter = chunked_arr.iter().skip(first);
+    for _ in 0..first {
+        out.push(Zero::zero());
+    }
+
+    // The next element of `iter` is definitely `Some(Some(v))`, because we skipped the first
+    // elements `first` and if all values were missing we'd have done an early return.
+    let mut low = iter.next().unwrap().unwrap();
+    out.push(low);
+    while let Some(next) = iter.next() {
+        if let Some(v) = next {
+            out.push(v);
+            low = v;
+        } else {
+            let mut steps = 1 as IdxSize;
+            for next in iter.by_ref() {
+                steps += 1;
+                if let Some(high) = next {
+                    let steps_n: T::Native = NumCast::from(steps).unwrap();
+                    interpolation_branch(low, high, steps, steps_n, &mut out);
+                    out.push(high);
+                    low = high;
+                    break;
+                }
+            }
+        }
+    }
+    if first != 0 || last != chunked_arr.len() {
+        let mut validity = MutableBitmap::with_capacity(chunked_arr.len());
+        validity.extend_constant(chunked_arr.len(), true);
+
+        for i in 0..first {
+            unsafe { validity.set_unchecked(i, false) };
+        }
+
+        for i in last..chunked_arr.len() {
+            unsafe { validity.set_unchecked(i, false) };
+            out.push(Zero::zero())
+        }
+
+        let array = PrimitiveArray::new(
+            T::get_dtype().to_arrow(true),
+            out.into(),
+            Some(validity.into()),
+        );
+        ChunkedArray::with_chunk(chunked_arr.name(), array)
+    } else {
+        ChunkedArray::from_vec(chunked_arr.name(), out)
+    }
+}
+
+fn linear_interp_signed<T: PolarsNumericType>(ca: &ChunkedArray<T>) -> Series
+where
+    ChunkedArray<T>: IntoSeries,
+{
+    interpolate_impl(ca, signed_interp::<T::Native>).into_series()
+}
+
+#[polars_expr(output_type=Int64)]
+fn interpolate(inputs: &[Series]) -> PolarsResult<Series> {
+    let s = &inputs[0];
+    let ca = s.i64()?;
+    let mut out: Int64Chunked = interpolate_impl(ca, signed_interp::<i64>);
+    out.rename(ca.name());
+    Ok(out.into_series())
 }

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -405,11 +405,11 @@ where
         validity.extend_constant(chunked_arr.len(), true);
 
         for i in 0..first {
-            unsafe { validity.set_unchecked(i, false) };
+            validity.set(i, false);
         }
 
         for i in last..chunked_arr.len() {
-            unsafe { validity.set_unchecked(i, false) };
+            validity.set(i, false);
             out.push(Zero::zero())
         }
 

--- a/test_plugin.py
+++ b/test_plugin.py
@@ -2,8 +2,6 @@ import polars as pl
 import minimal_plugin as mp
 from polars.testing import assert_frame_equal
 
-import pytest
-
 
 def test_noop():
     df = pl.DataFrame(

--- a/test_plugin.py
+++ b/test_plugin.py
@@ -2,6 +2,8 @@ import polars as pl
 import minimal_plugin as mp
 from polars.testing import assert_frame_equal
 
+import pytest
+
 
 def test_noop():
     df = pl.DataFrame(
@@ -63,6 +65,9 @@ def test_sum_i64():
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.xfail(
+    reason="Upstream is failing with: this expression cannot run in the group_by context"
+)
 def test_cum_sum():
     df = pl.DataFrame(
         {
@@ -179,6 +184,9 @@ def test_reverse_geocode():
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.xfail(
+    reason="Upstream is failing with: this expression cannot run in the group_by context"
+)
 def test_vertical_weighted_mean():
     df = pl.DataFrame(
         {

--- a/test_plugin.py
+++ b/test_plugin.py
@@ -65,9 +65,6 @@ def test_sum_i64():
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="Upstream is failing with: this expression cannot run in the group_by context"
-)
 def test_cum_sum():
     df = pl.DataFrame(
         {
@@ -184,9 +181,6 @@ def test_reverse_geocode():
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="Upstream is failing with: this expression cannot run in the group_by context"
-)
 def test_vertical_weighted_mean():
     df = pl.DataFrame(
         {


### PR DESCRIPTION
This PR introduces a new chapter, in which we advise plugin and polars developers against returning a `Vec<Option<T>>` instead of `Vec<T>` whenever they can.