### PR TITLE
docs: Acknowledge internship contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ Logo
 ----
 
 Thanks to [Olha Urdeichuk](https://www.fiverr.com/olhaurdeichuk) for the illustration.
+
+Funding
+-------
+
+Thank you to [Quansight Labs](https://labs.quansight.org/) for having provided support to this project during their internships
+programme, during which [Bruno Conde](https://github.com/condekind) made very significant contributions to chapters on Strings,
+performance (`Vec<Option<T>>` vs. `Vec<T>`), nested data types (Array, List, Struct), the CI process, and the "can we run doom?" extra.


### PR DESCRIPTION
Hey @condekind @melissawm - does this look alright? any suggestions?

---

I'd originally said that I wanted to make a new github org for this project, but as it turns out that changes the links (e.g. https://marcogorelli.github.io/narwhals/ is now a dead link), and the current link is already linked to in several places. So, I think it would be better to keep as-is, and to recognise the internship programme on the README if that's ok