### PR TITLE
Fixed broken link to Polars user guide

### DIFF
--- a/docs/where_to_go.md
+++ b/docs/where_to_go.md
@@ -7,7 +7,7 @@ and reading [The Rust Programming Language](https://doc.rust-lang.org/book).
 Or at least, the first 10 chapters.
 
 Next, you may be interested in looking at existing plugins for inspiration.
-There's a nice list of them in the official user guide: https://docs.pola.rs/user-guide/expressions/plugins/.
+There's a nice list of them in the official user guide: https://docs.pola.rs/user-guide/plugins/your-first-polars-plugin/#community-plugins.
 
 Finally, you should definitely join the Discord Server, where there's a channel
 dedicated to plugins: https://discord.gg/4UfP5cfBE7.


### PR DESCRIPTION
There is a broken link in the final chapter of the docs. The page it links to seems to be moved recently. 

In this fix I also link directly to the community plugin section, instead of to the page in general. 