### PR TITLE
Update docs to use Signed from num_traits instead of pyo3_polars

### DIFF
--- a/docs/abs.md
+++ b/docs/abs.md
@@ -139,8 +139,12 @@ where
 }
 ```
 Make sure to add
+```toml
+num-traits = "0.2.19"
+```
+as a dependency in `Cargo.toml` and
 ```Rust
-use pyo3_polars::export::polars_core::export::num::Signed;
+use num_traits::Signed;
 ```
 to the top of the `src/expression.rs` file.
 


### PR DESCRIPTION
In [2. How to do ABSolutely nothing](https://marcogorelli.github.io/polars-plugins-tutorial/abs/#abs_numeric), I was getting error:

```
error[E0433]: failed to resolve: could not find `export` in `polars_core`
 --> src\expressions.rs:2:39
  |
2 | use pyo3_polars::export::polars_core::export::num::Signed;
  |                                       ^^^^^^ could not find `export` in `polars_core`
```
Based on `src/expressions.rs` and `Cargo.toml`, I think `Signed` should be imported from `num_traits`.